### PR TITLE
Fix v10 bug for shorthand attributes

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -39,7 +39,7 @@ export class SimpleActor extends Actor {
   getRollData() {
 
     // Copy the actor's system data
-    const data = this.toObject(false);
+    const data = this.toObject(false).system;
     const shorthand = game.settings.get("worldbuilding", "macroShorthand");
     const formulaAttributes = [];
     const itemAttributes = [];
@@ -148,7 +148,7 @@ export class SimpleActor extends Actor {
 
       // Delete the original attributes key if using the shorthand syntax.
       if ( !!shorthand ) {
-        delete itemData.attributes;
+        delete itemData.system.attributes;
       }
       obj[key] = itemData;
       return obj;

--- a/module/actor.js
+++ b/module/actor.js
@@ -58,7 +58,7 @@ export class SimpleActor extends Actor {
 
     // Remove the attributes if necessary.
     if ( !!shorthand ) {
-      delete data.system.attributes;
+      delete data.attributes;
       delete data.attr;
       delete data.groups;
     }
@@ -75,7 +75,7 @@ export class SimpleActor extends Actor {
    */
   _applyShorthand(data, formulaAttributes, shorthand) {
     // Handle formula attributes when the short syntax is disabled.
-    for ( let [k, v] of Object.entries(data.system.attributes || {}) ) {
+    for ( let [k, v] of Object.entries(data.attributes || {}) ) {
       // Make an array of formula attributes for later reference.
       if ( v.dtype === "Formula" ) formulaAttributes.push(k);
       // Add shortened version of the attributes.
@@ -148,7 +148,7 @@ export class SimpleActor extends Actor {
 
       // Delete the original attributes key if using the shorthand syntax.
       if ( !!shorthand ) {
-        delete itemData.system.attributes;
+        delete itemData.attributes;
       }
       obj[key] = itemData;
       return obj;
@@ -220,19 +220,19 @@ export class SimpleActor extends Actor {
         attr = attrKey[1];
       }
       // Non-grouped attributes.
-      if ( data.system.attributes[k]?.value ) {
-        data.system.attributes[k].value = Roll.replaceFormulaData(String(data.system.attributes[k].value), data);
+      if ( data.attributes[k]?.value ) {
+        data.attributes[k].value = Roll.replaceFormulaData(String(data.attributes[k].value), data);
       }
       // Grouped attributes.
       else if ( attr ) {
-        data.system.attributes[k][attr].value = Roll.replaceFormulaData(String(data.system.attributes[k][attr].value), data);
+        data.attributes[k][attr].value = Roll.replaceFormulaData(String(data.attributes[k][attr].value), data);
       }
 
       // Duplicate values to shorthand.
       if ( !!shorthand ) {
         // Non-grouped attributes.
-        if ( data.system.attributes[k]?.value ) {
-          data[k] = data.system.attributes[k].value;
+        if ( data.attributes[k]?.value ) {
+          data[k] = data.attributes[k].value;
         }
         // Grouped attributes.
         else {
@@ -241,7 +241,7 @@ export class SimpleActor extends Actor {
             if ( !data[k] ) {
               data[k] = {};
             }
-            data[k][attr] = data.system.attributes[k][attr].value;
+            data[k][attr] = data.attributes[k][attr].value;
           }
         }
       }

--- a/module/actor.js
+++ b/module/actor.js
@@ -58,7 +58,7 @@ export class SimpleActor extends Actor {
 
     // Remove the attributes if necessary.
     if ( !!shorthand ) {
-      delete data.attributes;
+      delete data.system.attributes;
       delete data.attr;
       delete data.groups;
     }
@@ -75,7 +75,7 @@ export class SimpleActor extends Actor {
    */
   _applyShorthand(data, formulaAttributes, shorthand) {
     // Handle formula attributes when the short syntax is disabled.
-    for ( let [k, v] of Object.entries(data.attributes || {}) ) {
+    for ( let [k, v] of Object.entries(data.system.attributes || {}) ) {
       // Make an array of formula attributes for later reference.
       if ( v.dtype === "Formula" ) formulaAttributes.push(k);
       // Add shortened version of the attributes.
@@ -148,7 +148,7 @@ export class SimpleActor extends Actor {
 
       // Delete the original attributes key if using the shorthand syntax.
       if ( !!shorthand ) {
-        delete itemData.attributes;
+        delete itemData.system.attributes;
       }
       obj[key] = itemData;
       return obj;
@@ -220,19 +220,19 @@ export class SimpleActor extends Actor {
         attr = attrKey[1];
       }
       // Non-grouped attributes.
-      if ( data.attributes[k]?.value ) {
-        data.attributes[k].value = Roll.replaceFormulaData(String(data.attributes[k].value), data);
+      if ( data.system.attributes[k]?.value ) {
+        data.system.attributes[k].value = Roll.replaceFormulaData(String(data.system.attributes[k].value), data);
       }
       // Grouped attributes.
       else if ( attr ) {
-        data.attributes[k][attr].value = Roll.replaceFormulaData(String(data.attributes[k][attr].value), data);
+        data.system.attributes[k][attr].value = Roll.replaceFormulaData(String(data.system.attributes[k][attr].value), data);
       }
 
       // Duplicate values to shorthand.
       if ( !!shorthand ) {
         // Non-grouped attributes.
-        if ( data.attributes[k]?.value ) {
-          data[k] = data.attributes[k].value;
+        if ( data.system.attributes[k]?.value ) {
+          data[k] = data.system.attributes[k].value;
         }
         // Grouped attributes.
         else {
@@ -241,7 +241,7 @@ export class SimpleActor extends Actor {
             if ( !data[k] ) {
               data[k] = {};
             }
-            data[k][attr] = data.attributes[k][attr].value;
+            data[k][attr] = data.system.attributes[k][attr].value;
           }
         }
       }

--- a/module/actor.js
+++ b/module/actor.js
@@ -111,10 +111,10 @@ export class SimpleActor extends Actor {
     // Map all items data using their slugified names
     data.items = this.items.reduce((obj, item) => {
       const key = item.name.slugify({strict: true});
-      const itemData = item.toObject(false);
+      const itemData = item.toObject(false).system;
 
       // Add items to shorthand and note which ones are formula attributes.
-      for ( let [k, v] of Object.entries(itemData.system.attributes) ) {
+      for ( let [k, v] of Object.entries(itemData.attributes) ) {
         // When building the attribute list, prepend the item name for later use.
         if ( v.dtype === "Formula" ) itemAttributes.push(`${key}..${k}`);
         // Add shortened version of the attributes.
@@ -148,7 +148,7 @@ export class SimpleActor extends Actor {
 
       // Delete the original attributes key if using the shorthand syntax.
       if ( !!shorthand ) {
-        delete itemData.system.attributes;
+        delete itemData.attributes;
       }
       obj[key] = itemData;
       return obj;


### PR DESCRIPTION
- Fixed an issue where shorthand attribute handling in actor.getRollData() wasn't accounting for the new `system` prop when generating the new props for shorthand attributes.
- Note: I think there may be some other areas in the getRollData() (particularly around item attributes) where additional work may be needed. I opted for an MVP on this for issues I encountered while working on the v10 upgrade for Simple Worldbuilding Plus.