### PR TITLE
Use new grid configuration syntax in system.json for v12

### DIFF
--- a/system.json
+++ b/system.json
@@ -30,8 +30,10 @@
     "minimum": "10",
     "verified": "11"
   },
-  "gridDistance": 5,
-  "gridUnits": "ft",
+  "grid": {
+    "distance": 5,
+    "units": "ft"
+  },
   "primaryTokenAttribute": "health",
   "secondaryTokenAttribute": "power",
   "manifest": "https://raw.githubusercontent.com/foundryvtt/worldbuilding/master/system.json",


### PR DESCRIPTION
A very simple fix to the grid configuration syntax in `system.json` for #66 