### PR TITLE
Fix for shorthand formula

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -176,7 +176,7 @@ export class SimpleActor extends Actor {
       let formula = '';
       if ( !!shorthand ) {
         // Handle grouped attributes first.
-        if ( data.items[item][k][gk] ) {
+        if ( data.items[item][k][gk] !== undefined ) {
           formula = data.items[item][k][gk].replace('@item.', `@items.${item}.`);
           data.items[item][k][gk] = Roll.replaceFormulaData(formula, data);
         }

--- a/module/actor.js
+++ b/module/actor.js
@@ -176,7 +176,7 @@ export class SimpleActor extends Actor {
       let formula = '';
       if ( !!shorthand ) {
         // Handle grouped attributes first.
-        if ( data.items[item][k][gk] !== undefined ) {
+        if ( data.items[item][k]?.[gk] !== undefined ) {
           formula = data.items[item][k][gk].replace('@item.', `@items.${item}.`);
           data.items[item][k][gk] = Roll.replaceFormulaData(formula, data);
         }


### PR DESCRIPTION
Fix for shorthand formulae that are grouped but also evaluate to an empty string being interpreted as non-grouped and causing error.