### PR TITLE
fix group heading boxes appearing above floating attribute headings

### DIFF
--- a/styles/simple.css
+++ b/styles/simple.css
@@ -161,6 +161,7 @@
   border-radius: 2px;
   text-align: left;
   font-weight: bold;
+  z-index: 1;
 }
 .worldbuilding .attributes-list {
   list-style: none;


### PR DESCRIPTION
The group name box appears above the floating attributes header. This pushes the header back to the top.